### PR TITLE
Makefile: utilize `MANPREFIX'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ CFLAGS  = -std=c99 -pedantic -Wall -Wextra -Werror -O2
 LDFLAGS = -lX11 -lpng16
 
 PREFIX  = ${HOME}/.local
+MANPREFIX = ${PREFIX}/share/man
 
 install:
 	mkdir -p ${PREFIX}/bin
-	mkdir -p ${PREFIX}/man/man1
+	mkdir -p ${MANPREFIX}/man1
 	cp quadro ${PREFIX}/bin
-	cp quadro.1 ${PREFIX}/man/man1
+	cp quadro.1 ${MANPREFIX}/man1
 
 uninstall:
 	rm ${PREFIX}/bin/quadro
-	rm ${PREFIX}/man/man1/quadro.1
+	rm ${MANPREFIX}/man1/quadro.1
 
 clean:
 	rm -f quadro


### PR DESCRIPTION
Instead of `PREFIX' for man page installation, use `MANPREFIX'