### PR TITLE
stop `strcpy`'ing static strings

### DIFF
--- a/quadro.c
+++ b/quadro.c
@@ -22,17 +22,15 @@ int main(int argc, char *argv[]) {
     int attrx = 0;
     int attry = 0;
 
-    const char default_filename[] = "screenshot.png";
-    char *filename = alloca(sizeof default_filename);
-    strcpy(filename, default_filename);
+    char *filename = "screenshot.png";
 
     int opt;
     while ((opt = getopt(argc, argv, "f:g:")) != -1) {
         switch (opt) {
         case 'f': {
-            if (strlen(optarg) > strlen(filename))
-                filename = alloca(strlen(optarg));
-            strcpy(filename, optarg);
+            // optarg points to argv stack space that lives
+            // throughout the entire program
+            filename = optarg;
             break;
         }
         case 'g':


### PR DESCRIPTION
* `filename` will either point somewhere in the .TEXT segment or to `argv` space. In both cases we don't need to duplicate the value it points to. 

I checked that this does not screw something up through `valgrind --leak-check=full --show-leak-kinds=all ./quadro -f sucles.png -g 1200x700`, with `quadro` compiled with `-g`
